### PR TITLE
MW-141 Navbar width fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "gatsby-plugin-facebook-pixel": "1.0.5",
         "gatsby-plugin-google-fonts": "1.0.1",
         "gatsby-plugin-google-gtag": "3.14.0",
-        "gatsby-plugin-google-tagmanager": "^3.5.0",
+        "gatsby-plugin-google-tagmanager": "3.5.0",
         "gatsby-plugin-image": "^1.4.0",
         "gatsby-plugin-layout": "^2.4.0",
         "gatsby-plugin-mdx": "^2.4.0",

--- a/src/components/blog/BlogPostsContent.js
+++ b/src/components/blog/BlogPostsContent.js
@@ -16,7 +16,7 @@ const Container = styled(BlogContent)`
   ${media.desktop`
     padding-bottom: 0;
     padding-top: 8rem;
-    width: 129rem;
+    width: auto;
     max-width: 129rem;
   `};
 

--- a/src/components/blog/PostsTiles.js
+++ b/src/components/blog/PostsTiles.js
@@ -12,6 +12,7 @@ const Container = styled.div`
   flex-wrap: wrap;
   justify-content: start;
   ${media.desktop`
+  justify-content: center;
     gap: 0px 35px;
   `}
 `;

--- a/src/components/pages/Content.js
+++ b/src/components/pages/Content.js
@@ -10,7 +10,7 @@ const Content = styled(BaseContent)`
       max-width: 100%;
   `};
   ${media.ultraWide`
-      width: 116rem;
+      width: 100%;
       max-width: 116rem;
   `}
 `;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -21,7 +21,7 @@ const BlogFeatureArticleContent = styled(BlogContent)`
   padding-top: 0;
   ${media.desktop`
     padding-top: 5rem;
-    width: 129rem;
+    width: auto;
     max-width: 129rem;
     adding-bottom: 6.5rem;
   `}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -23,7 +23,7 @@ const BlogFeatureArticleContent = styled(BlogContent)`
     padding-top: 5rem;
     width: auto;
     max-width: 129rem;
-    adding-bottom: 6.5rem;
+    padding-bottom: 6.5rem;
   `}
 `;
 // const SearchContainer = styled(BlogContent)`


### PR DESCRIPTION
Previously Footer would be shorter than Navbar and Main Content boxes on resolutions below 1400px and above mobile, resulting in something like this:
![image](https://user-images.githubusercontent.com/67440406/148561329-62e73215-a397-46b4-9595-28dce16bc0db.png)
# Changes
- Featured post has auto width
- Rest of the posts have also auto width, resulting in two columns of posts on resolutions below 1400px. These columns are centered.
- Footer has same width as navbar
